### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
         name: Report
         runs-on: ubuntu-latest
         needs: [test]
+        permissions:
+            contents: read
+            secrets: read
         steps:
             - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/ghettovoice/abnf/security/code-scanning/8](https://github.com/ghettovoice/abnf/security/code-scanning/8)

To fix this issue, we need to define an explicit `permissions` block for the entire workflow or for specific jobs. Since the `Report` job highlighted by CodeQL uses the `GITHUB_TOKEN`, we should add a `permissions` block limiting access to just the required scopes for the job. In this case, the token only needs `contents: read` to download artifacts and `secrets: read` to access the `COVERALLS_TOKEN`.

The fix is applied by adding the `permissions` block within the `Report` job definition, ensuring that only the minimal permissions required are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
