### PR TITLE
Wrap single operator rule to append rule's key

### DIFF
--- a/pkg/abnf_gen/code_generator_test.go
+++ b/pkg/abnf_gen/code_generator_test.go
@@ -2,6 +2,7 @@ package abnf_gen_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
 
@@ -315,4 +316,23 @@ func (*RulesDescr) R2(in []byte, ns *abnf.Nodes) error {
 	if got := dst.String(); got != want {
 		t.Fatalf("got != want\ndiff (-got +want)\n%v", cmp.Diff(got, want))
 	}
+}
+
+func TestCodeGenerator_tmp(t *testing.T) {
+	rules := bytes.NewBuffer([]byte(
+		"r1 = \"1\" / \"2\"\n" +
+			"r2 = r1\n",
+	))
+	g := &abnf_gen.CodeGenerator{
+		PackageName: "extend_rule",
+	}
+	if _, err := g.ReadFrom(rules); err != nil {
+		t.Fatal(err)
+	}
+
+	var dst bytes.Buffer
+	if _, err := g.WriteTo(&dst); err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(dst.String())
 }

--- a/pkg/abnf_gen/parsers.go
+++ b/pkg/abnf_gen/parsers.go
@@ -246,10 +246,15 @@ func parseRuleslistNode(n *abnf.Node) map[string]rule {
 		if n, ok := n.GetNode("rule"); ok {
 			newRule := parseRuleNode(n)
 			if foundRule, ok := rules[newRule.name]; ok && newRule.extend {
-				rules[newRule.name] = mergeRules(newRule.name, foundRule, newRule)
-			} else {
-				rules[newRule.name] = newRule
+				newRule = mergeRules(newRule.name, foundRule, newRule)
 			}
+			if op, ok := newRule.oprt.(ruleNameOperator); ok {
+				newRule.oprt = concatOperator{
+					k:     op.k,
+					oprts: []operator{op},
+				}
+			}
+			rules[newRule.name] = newRule
 		}
 	}
 	return rules


### PR DESCRIPTION
Operator in a single-op rule is wrapped to concat with rule's name. This allows do not loose the nodes with this rule name.