### PR TITLE
Memory usage optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,14 @@ release:
 	@echo "  git push --follow-tags"
 
 bench:
-	@if [ -z "$(PKG)" ] || [ "$(PKG)" = "..." ] ; then \
+	@if [ -z "$(PKG)" ]; then \
 		echo "Error: PKG is not set. Usage: make bench PKG=a/b/c" >&2; \
 		exit 1; \
 	fi
-	$(eval PREFIX := $(shell if [ "$(PKG)" = "." ]; then echo "abnf"; else echo "$(PKG)" | sed 's#/#_#g'; fi ))
+	$(eval PREFIX := $(shell if [ "$(PKG)" = "..." ] || [ "$(PKG)" = "." ]; then echo "abnf_"; else echo "$(PKG)" | sed 's#/#_#g'; fi ))
 	$(eval SUFFIX := $(shell echo "_$(shell date +%Y%m%d%H%M%S)"))
-	go test -vet=all -run=. -bench=. -benchmem -count=10 \
-		-memprofile=$(PREFIX)_mem$(SUFFIX).out \
-		-cpuprofile=$(PREFIX)_cpu$(SUFFIX).out \
+	go test -vet=all -run=^$$ -bench=. -benchmem -count=10 \
+		-memprofile=$(PREFIX)mem$(SUFFIX).out \
+		-cpuprofile=$(PREFIX)cpu$(SUFFIX).out \
 		./$(PKG) \
-	| tee $(PREFIX)_bench$(SUFFIX).out
+	| tee $(PREFIX)bench$(SUFFIX).out

--- a/errors.go
+++ b/errors.go
@@ -75,18 +75,18 @@ const multiErrCap = 10
 
 var multiErrPool = &sync.Pool{
 	New: func() any {
-		errs := multiError(make([]error, 0, multiErrCap))
-		return &errs
+		me := make(multiError, 0, multiErrCap)
+		return &me
 	},
 }
 
-func newMultiErr(c uint) multiError {
-	var err multiError
+func newMultiErr(c uint) *multiError {
+	var err *multiError
 	if c <= multiErrCap {
-		errPtr := multiErrPool.Get().(*multiError)
-		err = *errPtr
+		err = multiErrPool.Get().(*multiError)
 	} else {
-		err = make(multiError, 0, c)
+		me := make(multiError, 0, c)
+		err = &me
 	}
 	return err
 }

--- a/operators_test.go
+++ b/operators_test.go
@@ -15,13 +15,13 @@ func TestOperator(t *testing.T) {
 		name    string
 		op      abnf.Operator
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"literal 1",
 			abnf.Literal("qwe", []byte("qwe")),
 			[]byte("Qwerty"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "qwe", Value: []byte("Qwe")},
 			},
 			nil,
@@ -35,7 +35,7 @@ func TestOperator(t *testing.T) {
 		{"literal 3",
 			abnf.Literal("м", []byte("м")),
 			[]byte("МИР"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "м", Value: []byte("М")},
 			},
 			nil,
@@ -43,7 +43,7 @@ func TestOperator(t *testing.T) {
 		{"literal 4",
 			abnf.LiteralCS("Qwe", []byte("Qwe")),
 			[]byte("Qwerty"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "Qwe", Value: []byte("Qwe")},
 			},
 			nil,
@@ -64,7 +64,7 @@ func TestOperator(t *testing.T) {
 		{"range 1",
 			abnf.Range("%x61-7A", []byte{97}, []byte{122}),
 			[]byte("qwe"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "%x61-7A", Value: []byte("q")},
 			},
 			nil,
@@ -84,7 +84,7 @@ func TestOperator(t *testing.T) {
 		{"range 4",
 			abnf.Range("%x5D-10FFFF", []byte{93}, []byte{16, 255, 255}),
 			[]byte("xxx"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "%x5D-10FFFF", Value: []byte("x")},
 			},
 			nil,
@@ -96,7 +96,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("b", []byte("b")),
 			),
 			[]byte("a"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"a" / "b"`,
 					Value: []byte("a"),
@@ -113,7 +113,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("b", []byte("b")),
 			),
 			[]byte("b"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"a" / "b"`,
 					Value: []byte("b"),
@@ -136,7 +136,7 @@ func TestOperator(t *testing.T) {
 		{"alt 4",
 			abnf.Alt(`"a" / "ab"`, abnf.Literal(`"a"`, []byte("a")), abnf.Literal(`"ab"`, []byte("ab"))),
 			[]byte("abc"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"a" / "ab"`,
 					Value: []byte("ab"),
@@ -161,7 +161,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal(`"ab"`, []byte("ab")),
 			),
 			[]byte("abc"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"b" / "a" / "ab"`,
 					Value: []byte("a"),
@@ -180,7 +180,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("c", []byte("c")),
 			),
 			[]byte("abc"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"a" "b" "c"`,
 					Value: []byte("abc"),
@@ -207,7 +207,7 @@ func TestOperator(t *testing.T) {
 		{"opt 1",
 			abnf.Optional(`[ "a" ]`, abnf.Literal("a", []byte("a"))),
 			[]byte("abc"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `[ "a" ]`,
 					Value: []byte("a"),
@@ -225,7 +225,7 @@ func TestOperator(t *testing.T) {
 		{"opt 2",
 			abnf.Optional(`[ "a" ]`, abnf.Literal("a", []byte("a"))),
 			[]byte("b"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `[ "a" ]`,
 					Value: []byte{},
@@ -237,7 +237,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 1",
 			abnf.Repeat(`*1( "a" )`, 0, 1, abnf.Literal("a", []byte("a"))),
 			[]byte("aaa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `*1( "a" )`,
 					Value: []byte("a"),
@@ -255,7 +255,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 2",
 			abnf.Repeat(`*1( "a" )`, 0, 1, abnf.Literal("a", []byte("a"))),
 			[]byte("bbb"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `*1( "a" )`,
 					Value: []byte{},
@@ -272,7 +272,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 4",
 			abnf.Repeat(`2*3( "a" )`, 2, 3, abnf.Literal("a", []byte("a"))),
 			[]byte("aa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `2*3( "a" )`,
 					Value: []byte("aa"),
@@ -287,7 +287,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 5",
 			abnf.Repeat(`2*3( "a" )`, 2, 3, abnf.Literal("a", []byte("a"))),
 			[]byte("aaa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `2*3( "a" )`,
 					Value: []byte("aaa"),
@@ -311,7 +311,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 6",
 			abnf.Repeat(`3( "a" )`, 3, 2, abnf.Literal("a", []byte("a"))),
 			[]byte("aaa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `3( "a" )`,
 					Value: []byte("aaa"),
@@ -333,7 +333,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 8",
 			abnf.Repeat0Inf(`*( "a" )`, abnf.Literal("a", []byte("a"))),
 			[]byte(""),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: `*( "a" )`, Value: []byte{}},
 			},
 			nil,
@@ -341,7 +341,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 9",
 			abnf.Repeat0Inf(`*( "a" )`, abnf.Literal("a", []byte("a"))),
 			[]byte("aaa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `*( "a" )`,
 					Value: []byte("aaa"),
@@ -376,7 +376,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 10",
 			abnf.Repeat1Inf(`1*( "a" )`, abnf.Literal("a", []byte("a"))),
 			[]byte("aaa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `1*( "a" )`,
 					Value: []byte("aaa"),
@@ -407,7 +407,7 @@ func TestOperator(t *testing.T) {
 		{"repeat 11",
 			abnf.Repeat1Inf(`1*( "a" )`, abnf.Literal("a", []byte("a"))),
 			[]byte("a"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `1*( "a" )`,
 					Value: []byte("a"),
@@ -431,7 +431,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("bc", []byte("bc")),
 			),
 			[]byte("abc"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `[ "a" ] "bc"`,
 					Pos:   0,
@@ -457,7 +457,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("abc", []byte("abc")),
 			),
 			[]byte("abc"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `[ "a" ] "abc"`,
 					Pos:   0,
@@ -480,7 +480,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("aa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `[ "a" ] "a"`,
 					Pos:   0,
@@ -506,7 +506,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("aa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `[ "a" ] "a"`,
 					Pos:   0,
@@ -541,7 +541,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("a"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `[ "a" ] "a"`,
 					Pos:   0,
@@ -557,7 +557,7 @@ func TestOperator(t *testing.T) {
 		{"combo 6",
 			abnf.Repeat0Inf(`*( [ "a" ] )`, abnf.Optional(`[ "a" ]`, abnf.Literal("a", []byte("a")))),
 			[]byte(""),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `*( [ "a" ] )`,
 					Pos:   0,
@@ -569,7 +569,7 @@ func TestOperator(t *testing.T) {
 		{"combo 7",
 			abnf.Repeat0Inf(`*( [ "a" ] )`, abnf.Optional(`[ "a" ]`, abnf.Literal("a", []byte("a")))),
 			[]byte("aa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `*( [ "a" ] )`,
 					Pos:   0,
@@ -677,7 +677,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("aa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"a" *( "a" / "b" ) "a"`,
 					Pos:   0,
@@ -703,7 +703,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("aaa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"a" *( "a" / "b" ) "a"`,
 					Pos:   0,
@@ -743,7 +743,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("aaba"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `"a" *( "a" / "b" ) "a"`,
 					Pos:   0,
@@ -788,7 +788,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("a"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `(*"a" / *"b") "a"`,
 					Pos:   0,
@@ -817,7 +817,7 @@ func TestOperator(t *testing.T) {
 				abnf.Literal("a", []byte("a")),
 			),
 			[]byte("aa"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   `(*"a" / *"b") "a"`,
 					Pos:   0,
@@ -852,7 +852,7 @@ func TestOperator(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := c.op(c.in, 0, &ns)
+			err := c.op(c.in, 0, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("op(in, 0, nil) error = %q, want nil", err)
@@ -889,12 +889,12 @@ func BenchmarkLiteral(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := op(in, 0, &ns); err != nil {
+		if err := op(in, 0, ns); err != nil {
 			b.Errorf("operator returned error %q, want nil", err)
 			continue
 		}
-		if len(ns) != 1 {
-			b.Errorf("operator returned %d nodes, want 1", len(ns))
+		if ns.Len() != 1 {
+			b.Errorf("operator returned %d nodes, want 1", ns.Len())
 		}
 	}
 }
@@ -912,12 +912,12 @@ func BenchmarkLiteral_unicode(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := op(in, 0, &ns); err != nil {
+		if err := op(in, 0, ns); err != nil {
 			b.Errorf("operator returned error %q, want nil", err)
 			continue
 		}
-		if len(ns) != 1 {
-			b.Errorf("operator returned %d nodes, want 1", len(ns))
+		if ns.Len() != 1 {
+			b.Errorf("operator returned %d nodes, want 1", ns.Len())
 		}
 	}
 }
@@ -935,12 +935,12 @@ func BenchmarkLiteralCS(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := op(in, 0, &ns); err != nil {
+		if err := op(in, 0, ns); err != nil {
 			b.Errorf("operator returned error %q, want nil", err)
 			continue
 		}
-		if len(ns) != 1 {
-			b.Errorf("operator returned %d nodes, want 1", len(ns))
+		if ns.Len() != 1 {
+			b.Errorf("operator returned %d nodes, want 1", ns.Len())
 		}
 	}
 }
@@ -955,12 +955,12 @@ func BenchmarkRange(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := op(in, 0, &ns); err != nil {
+		if err := op(in, 0, ns); err != nil {
 			b.Errorf("operator returned error %q, want nil", err)
 			continue
 		}
-		if len(ns) != 1 {
-			b.Errorf("operator returned %d nodes, want 1", len(ns))
+		if ns.Len() != 1 {
+			b.Errorf("operator returned %d nodes, want 1", ns.Len())
 		}
 	}
 }
@@ -988,11 +988,11 @@ func BenchmarkAlt(tb *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				ns.Clear()
-				if err := op(in, 0, &ns); err != nil {
+				if err := op(in, 0, ns); err != nil {
 					b.Errorf("operator returned error %q, want nil", err)
 					continue
 				}
-				if len(ns) == 0 {
+				if ns.Len() == 0 {
 					b.Error("operator returned 0 nodes, want at least 1")
 				}
 			}
@@ -1013,11 +1013,11 @@ func BenchmarkConcat(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := op(in, 0, &ns); err != nil {
+		if err := op(in, 0, ns); err != nil {
 			b.Errorf("operator returned error %q, want nil", err)
 			continue
 		}
-		if len(ns) == 0 {
+		if ns.Len() == 0 {
 			b.Error("operator returned 0 nodes, want at least 1")
 		}
 	}
@@ -1042,11 +1042,11 @@ func BenchmarkRepeat0Inf(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				ns.Clear()
-				if err := op(in, 0, &ns); err != nil {
+				if err := op(in, 0, ns); err != nil {
 					b.Errorf("operator returned error %q, want nil", err)
 					continue
 				}
-				if len(ns) == 0 {
+				if ns.Len() == 0 {
 					b.Error("operator returned 0 nodes, want at least 1")
 				}
 			}
@@ -1076,11 +1076,11 @@ func BenchmarkCombo(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := op([]byte("abc"), 0, &ns); err != nil {
+		if err := op([]byte("abc"), 0, ns); err != nil {
 			b.Errorf("operator returned error %q, want nil", err)
 			continue
 		}
-		if len(ns) == 0 {
+		if ns.Len() == 0 {
 			b.Error("operator returned 0 nodes, want at least 1")
 		}
 	}
@@ -1097,19 +1097,19 @@ func ExampleConcat() {
 	ns := abnf.NewNodes()
 	defer ns.Free()
 
-	if err := op([]byte("ab"), 0, &ns); err != nil {
+	if err := op([]byte("ab"), 0, ns); err != nil {
 		panic(err)
 	}
 	fmt.Println(ns.Best())
 
 	ns.Clear()
-	if err := op([]byte("abcd"), 0, &ns); err != nil {
+	if err := op([]byte("abcd"), 0, ns); err != nil {
 		panic(err)
 	}
 	fmt.Println(ns.Best())
 
 	ns.Clear()
-	if err := op([]byte("abcdcd"), 0, &ns); err != nil {
+	if err := op([]byte("abcdcd"), 0, ns); err != nil {
 		panic(err)
 	}
 	fmt.Println(ns.Best())

--- a/pkg/abnf_core/rules_test.go
+++ b/pkg/abnf_core/rules_test.go
@@ -14,12 +14,12 @@ func TestRulesDescr_ALPHA(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"lc letter",
 			[]byte("a"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "ALPHA",
 					Value: []byte("a"),
@@ -32,7 +32,7 @@ func TestRulesDescr_ALPHA(t *testing.T) {
 		},
 		{"uc letter",
 			[]byte("Z"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "ALPHA",
 					Value: []byte("Z"),
@@ -56,7 +56,7 @@ func TestRulesDescr_ALPHA(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().ALPHA(c.in, &ns)
+			err := abnf_core.Rules().ALPHA(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().ALPHA(%q, nil) error = %v, want nil", c.in, err)
@@ -84,12 +84,12 @@ func TestRulesDescr_BIT(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"0",
 			[]byte("0"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "BIT",
 					Value: []byte("0"),
@@ -102,7 +102,7 @@ func TestRulesDescr_BIT(t *testing.T) {
 		},
 		{"1",
 			[]byte("1"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "BIT",
 					Value: []byte("1"),
@@ -126,7 +126,7 @@ func TestRulesDescr_BIT(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().BIT(c.in, &ns)
+			err := abnf_core.Rules().BIT(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().BIT(%q, nil) error = %v, want nil", c.in, err)
@@ -154,26 +154,26 @@ func TestRulesDescr_CHAR(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"~",
 			[]byte("~"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "CHAR", Value: []byte("~")},
 			},
 			nil,
 		},
 		{"a",
 			[]byte("a"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "CHAR", Value: []byte("a")},
 			},
 			nil,
 		},
 		{"0",
 			[]byte("0"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "CHAR", Value: []byte("0")},
 			},
 			nil,
@@ -186,7 +186,7 @@ func TestRulesDescr_CHAR(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().CHAR(c.in, &ns)
+			err := abnf_core.Rules().CHAR(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().CHAR(%q, nil) error = %v, want nil", c.in, err)
@@ -214,12 +214,12 @@ func TestRulesDescr_CRLF(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"crlf",
 			[]byte("\r\n"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "CRLF",
 					Value: []byte("\r\n"),
@@ -239,7 +239,7 @@ func TestRulesDescr_CRLF(t *testing.T) {
 		},
 		{"lf",
 			[]byte("\n"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "CRLF",
 					Value: []byte("\n"),
@@ -263,7 +263,7 @@ func TestRulesDescr_CRLF(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().CRLF(c.in, &ns)
+			err := abnf_core.Rules().CRLF(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().CRLF(%q, nil) error = %v, want nil", c.in, err)
@@ -291,12 +291,12 @@ func TestRulesDescr_CTL(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"ctl",
 			[]byte("\u001B"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "CTL",
 					Value: []byte("\u001B"),
@@ -315,7 +315,7 @@ func TestRulesDescr_CTL(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().CTL(c.in, &ns)
+			err := abnf_core.Rules().CTL(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().CTL(%q, nil) error = %v, want nil", c.in, err)
@@ -343,12 +343,12 @@ func TestRulesDescr_DIGIT(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"digit 0",
 			[]byte("0"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "DIGIT",
 					Value: []byte("0"),
@@ -358,7 +358,7 @@ func TestRulesDescr_DIGIT(t *testing.T) {
 		},
 		{"digit 9",
 			[]byte("9"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "DIGIT",
 					Value: []byte("9"),
@@ -379,7 +379,7 @@ func TestRulesDescr_DIGIT(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().DIGIT(c.in, &ns)
+			err := abnf_core.Rules().DIGIT(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().DIGIT(%q, nil) error = %v, want nil", c.in, err)
@@ -407,12 +407,12 @@ func TestRulesDescr_DQUOTE(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"double quote",
 			[]byte("\""),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "DQUOTE",
 					Value: []byte("\""),
@@ -433,7 +433,7 @@ func TestRulesDescr_DQUOTE(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().DQUOTE(c.in, &ns)
+			err := abnf_core.Rules().DQUOTE(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().DQUOTE(%q, nil) error = %v, want nil", c.in, err)
@@ -461,12 +461,12 @@ func TestRulesDescr_HEXDIG(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"hexdig 7",
 			[]byte("7"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "HEXDIG",
 					Value: []byte("7"),
@@ -479,7 +479,7 @@ func TestRulesDescr_HEXDIG(t *testing.T) {
 		},
 		{"hexdig A",
 			[]byte("A"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "HEXDIG",
 					Value: []byte("A"),
@@ -492,7 +492,7 @@ func TestRulesDescr_HEXDIG(t *testing.T) {
 		},
 		{"hexdig a",
 			[]byte("a"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "HEXDIG",
 					Value: []byte("a"),
@@ -516,7 +516,7 @@ func TestRulesDescr_HEXDIG(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().HEXDIG(c.in, &ns)
+			err := abnf_core.Rules().HEXDIG(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().HEXDIG(%q, nil) error = %v, want nil", c.in, err)
@@ -544,12 +544,12 @@ func TestRulesDescr_HTAB(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"htab",
 			[]byte("\t"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "HTAB",
 					Value: []byte("\t"),
@@ -570,7 +570,7 @@ func TestRulesDescr_HTAB(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().HTAB(c.in, &ns)
+			err := abnf_core.Rules().HTAB(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().HTAB(%q, nil) error = %v, want nil", c.in, err)
@@ -598,12 +598,12 @@ func TestRulesDescr_LWSP(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"space",
 			[]byte(" "),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "LWSP",
 					Value: []byte(" "),
@@ -629,7 +629,7 @@ func TestRulesDescr_LWSP(t *testing.T) {
 		},
 		{"crlf space",
 			[]byte("\n "),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "LWSP",
 					Value: []byte("\n "),
@@ -675,7 +675,7 @@ func TestRulesDescr_LWSP(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().LWSP(c.in, &ns)
+			err := abnf_core.Rules().LWSP(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().LWSP(%q, nil) error = %v, want nil", c.in, err)
@@ -703,12 +703,12 @@ func TestRulesDescr_OCTET(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"o",
 			[]byte("o"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "OCTET", Value: []byte("o")},
 			},
 			nil,
@@ -721,7 +721,7 @@ func TestRulesDescr_OCTET(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().OCTET(c.in, &ns)
+			err := abnf_core.Rules().OCTET(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().OCTET(%q, nil) error = %v, want nil", c.in, err)
@@ -749,12 +749,12 @@ func TestRulesDescr_VCHAR(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"vchar",
 			[]byte("`"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{Key: "VCHAR", Value: []byte("`")},
 			},
 			nil,
@@ -767,7 +767,7 @@ func TestRulesDescr_VCHAR(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().VCHAR(c.in, &ns)
+			err := abnf_core.Rules().VCHAR(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().VCHAR(%q, nil) error = %v, want nil", c.in, err)
@@ -795,12 +795,12 @@ func TestRulesDescr_WSP(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      []byte
-		wantNs  abnf.Nodes
+		wantNs  *abnf.Nodes
 		wantErr error
 	}{
 		{"space",
 			[]byte(" "),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "WSP",
 					Value: []byte(" "),
@@ -813,7 +813,7 @@ func TestRulesDescr_WSP(t *testing.T) {
 		},
 		{"htab",
 			[]byte("\t"),
-			abnf.Nodes{
+			&abnf.Nodes{
 				{
 					Key:   "WSP",
 					Value: []byte("\t"),
@@ -832,7 +832,7 @@ func TestRulesDescr_WSP(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			err := abnf_core.Rules().WSP(c.in, &ns)
+			err := abnf_core.Rules().WSP(c.in, ns)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("abnf_core.Rules().WSP(%q, nil) error = %v, want nil", c.in, err)
@@ -889,11 +889,11 @@ func BenchmarkToken(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := token([]byte("!aaa.bbb+ccc"), 0, &ns); err != nil {
+		if err := token([]byte("!aaa.bbb+ccc"), 0, ns); err != nil {
 			b.Errorf("operator returned error %q, want nil", err)
 			continue
 		}
-		if len(ns) == 0 {
+		if ns.Len() == 0 {
 			b.Error("operator returned 0 nodes, want at least 1")
 		}
 	}

--- a/pkg/abnf_def/rules_test.go
+++ b/pkg/abnf_def/rules_test.go
@@ -30,7 +30,7 @@ func TestRulesDescr_Rule(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ns.Clear()
-			if err := abnf_def.Rules().Rule([]byte(c.in), &ns); err != nil {
+			if err := abnf_def.Rules().Rule([]byte(c.in), ns); err != nil {
 				t.Fatalf("abnf_def.Rules().Rule(in, ns) error = %v, want nil", err)
 			}
 
@@ -61,7 +61,7 @@ func TestRulesDescr_Rulelist(t *testing.T) {
 			}
 
 			ns.Clear()
-			if err := abnf_def.Rules().Rulelist(in, &ns); err != nil {
+			if err := abnf_def.Rules().Rulelist(in, ns); err != nil {
 				t.Fatalf("abnf_def.Rules().Rulelist(in, nil) error = %v, want nil", err)
 			}
 
@@ -87,11 +87,11 @@ func BenchmarkRulesDescr_Rulelist(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		ns.Clear()
-		if err := abnf_def.Rules().Rulelist(in, &ns); err != nil {
+		if err := abnf_def.Rules().Rulelist(in, ns); err != nil {
 			b.Errorf("abnf_def.Rules().Rulelist(in, ns) error = %v, want nil", err)
 			continue
 		}
-		if len(ns) == 0 {
+		if ns.Len() == 0 {
 			b.Errorf("abnf_def.Rules().Rulelist(in, ns) = %+v, want not empty", ns)
 			continue
 		}

--- a/pkg/abnf_gen/parser_generator_test.go
+++ b/pkg/abnf_gen/parser_generator_test.go
@@ -39,11 +39,11 @@ func TestParserGenerator_Operators(t *testing.T) {
 	ns := abnf.NewNodes()
 	defer ns.Free()
 
-	if err := op([]byte("0"), 0, &ns); err != nil {
+	if err := op([]byte("0"), 0, ns); err != nil {
 		t.Fatalf("op([]byte(\"0\"), 0, nil) error = %v, want nil", err)
 	}
 
-	want := abnf.Nodes{
+	want := &abnf.Nodes{
 		{
 			Key:   "r1",
 			Value: []byte("0"),

--- a/pkg/abnf_gen/parsers.go
+++ b/pkg/abnf_gen/parsers.go
@@ -230,7 +230,7 @@ const (
 func parseRules(s []byte) (map[string]rule, error) {
 	ns := abnf.NewNodes()
 	defer ns.Free()
-	if err := abnf_def.Rules().Rulelist(s, &ns); err != nil {
+	if err := abnf_def.Rules().Rulelist(s, ns); err != nil {
 		return nil, errtrace.Wrap(fmt.Errorf("parse rules: %w", err))
 	}
 	n := ns.Best()


### PR DESCRIPTION
- use abnf.Nodes by pointer
- use multiError by pointer and allocc only when needed
- use small abnf.Nodes for children nodes
- use chunk of input for cache key