### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+    contents: read
 on:
     workflow_dispatch:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/ghettovoice/abnf/security/code-scanning/12](https://github.com/ghettovoice/abnf/security/code-scanning/12)

In general, to fix this class of problem you add a `permissions` section either at the workflow top level (to apply to all jobs) or on specific jobs, granting only the least privileges required. For this workflow, none of the jobs pushes commits, creates releases, or modifies issues/PRs; they only need to read repository contents and possibly read packages, which maps well to a minimal `contents: read` (and optionally `packages: read` if packages are involved).

The single best fix here without changing existing functionality is to add a root-level `permissions` block just under the `name:` line, setting `contents: read`. This ensures: (1) all four jobs (`lint`, `vulncheck`, `test`, `report`) get a restricted token, (2) the behavior of the existing steps is preserved, since they only require read access, and (3) the CodeQL warning for the `report` job is resolved because the job now inherits explicit, least-privilege permissions. No imports or additional methods are needed since this is a YAML configuration change only.

Specifically, edit `.github/workflows/test.yml` to insert:

```yaml
permissions:
    contents: read
```

between line 1 (`name: Tests`) and line 2 (`on:`). No further changes are required in the jobs themselves.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
