### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,10 @@ on:
     schedule:
         - cron: '30 1 * * *'
     workflow_dispatch:
+permissions:
+    contents: write
+    issues: write
+    pull-requests: write
 jobs:
     stale:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ghettovoice/abnf/security/code-scanning/13](https://github.com/ghettovoice/abnf/security/code-scanning/13)

To fix this, add an explicit `permissions` block so the workflow does not rely on inherited defaults.  
Best approach here: define permissions at the **workflow root** (applies to all jobs unless overridden), since this workflow has a single job.

For `.github/workflows/stale.yml`, insert a top-level `permissions` section between `on:` and `jobs:` with only what `actions/stale@v10` needs:

- `contents: write` (as recommended by CodeQL message; also safe for repo interactions),
- `issues: write` (to mark/comment/close stale issues),
- `pull-requests: write` (to mark/comment/close stale PRs).

No imports, methods, or dependencies are needed—just YAML config change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
